### PR TITLE
Prevent showing "Hello, !" when myName = ""

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -11,7 +11,7 @@ function setUserName() {
     var myName = prompt('Please enter your name.');
     localStorage.setItem('name', myName);
     
-    if (myName === null) {
+    if (myName === null || myName === "") {
      helloLabel.textContext = 'Hello!';   
     } else {
       helloLabel.textContent = 'Hello, ' + myName + '!';


### PR DESCRIPTION
Whenever I press the button to show my name and press "OK" before I type anything, it says "Hello, !"

I added another condition under which the page would say "Hello!" to fix this.